### PR TITLE
Breakup /hybrid/ctl WH Playbook

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -22,7 +22,7 @@
     KNOWN_HOSTS: ~/.ssh/known_hosts
 
 - name: Clone Repositories
-  tags: git
+  tags: git update-git
   # Becoming root causes issues with key_file
   become: false
   git:

--- a/webhooks/cmd/main.go
+++ b/webhooks/cmd/main.go
@@ -44,6 +44,8 @@ func ctlHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
+	w.WriteHeader(http.StatusOK)
+
 	if strings.Contains(payload.Ref, "main") {
 		var ansi ansible.Runner
 		params := ansible.Params{
@@ -51,7 +53,19 @@ func ctlHandler(w http.ResponseWriter, r *http.Request) {
 			Log:	"goansi.log",
 			Cmd:	ansible.Cmd{
 				AnsibleCommand: "playbook",
-				Args: []string{	"-u", "jynx", "-i", "production", "--skip-tags", "deploy", "update-hybrid.yml" },
+				Args: []string{	"-u", "jynx", "-i", "production", "--tags", "update-git", "hybrid.yml" },
+			},
+		}
+
+		ansi = ansible.New(params)
+		ansi.Run()
+
+		params = ansible.Params{
+			User:	"jynx",
+			Log:	"goansi.log",
+			Cmd:	ansible.Cmd{
+				AnsibleCommand: "playbook",
+				Args: []string{	"-u", "jynx", "-i", "production", "--skip-tags", "deploy,git", "hybrid.yml" },
 			},
 		}
 
@@ -59,7 +73,6 @@ func ctlHandler(w http.ResponseWriter, r *http.Request) {
 		ansi.Run()
 	}
 	
-	w.WriteHeader(http.StatusOK)
 }
 
 func mainHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The /hybrid/ctl playbook 'update-hybrid' checksout the latest main
branch AND runs hybrid.yml, however it runs hybrid.yml as it was when
the command executed, which is probably a good thing but it's not what
we want.
To checkout the latest changes THEN run hybrid.yml we need to create and
run 2 seperate ansible.Runners, one to update git, the other to run the
playbook normally.