### PR TITLE
Hotfix: Remove Warnings in Docker Role

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
   - name: Add Docker Repository
     shell: dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+    args:
+      warn: no
     register: repo
     changed_when: repo.failed | bool
 


### PR DESCRIPTION
The 'shell' module gives a warning when it detects other modules you
could use instead of 'shell', such as 'dnf'. This is nice(?), but it
silently prevents the webhook from completing the playbook.
Turns off 'shell' module warnings by adding 'warn: no' to task.